### PR TITLE
Minor refactor for ModelManager

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -52,7 +52,6 @@ public class AddCommand extends UndoableCommand {
         requireNonNull(model);
         try {
             model.addPerson(toAdd);
-            model.sortPersonList();
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (DuplicatePersonException e) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -45,7 +45,6 @@ public class AddEventCommand extends UndoableCommand {
         requireNonNull(model);
         try {
             model.addEvent(toAdd);
-            model.sortEventList();
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (DuplicateEventException e) {
             throw new CommandException(MESSAGE_DUPLICATE_EVENT);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -79,7 +79,6 @@ public class EditCommand extends UndoableCommand {
 
         try {
             model.updatePerson(personToEdit, editedPerson);
-            model.sortPersonList();
         } catch (DuplicatePersonException dpe) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         } catch (PersonNotFoundException pnfe) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -147,6 +147,39 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * @throws PersonNotFoundException if the {@code key} is not in this {@code AddressBook}.
+     */
+    public boolean removePerson(ReadOnlyPerson key) throws PersonNotFoundException {
+        if (persons.remove(key)) {
+            return true;
+        } else {
+            throw new PersonNotFoundException();
+        }
+    }
+
+    /**
+     * Sorts the persons according to their name.
+     */
+    public void sortPersonList() {
+        persons.sortPersons();
+    }
+
+    /*****************************************************
+     * Event-level operations
+     *****************************************************/
+
+    /**
+     * Adds an event to the address book.
+     *
+     * @throws DuplicateEventException if an equivalent event already exists.
+     */
+    public void addEvent(ReadOnlyEvent e) throws DuplicateEventException {
+        Event newEvent = new Event(e);
+        events.add(newEvent);
+    }
+
+    /**
      * Replaces the given event {@code target} in the list with {@code editedReadOnlyPerson}.
      * {@code AddressBook}'s tag list will be updated with the tags of {@code editedReadOnlyPerson}.
      *
@@ -163,6 +196,34 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         events.setEvent(target, editedEvent);
     }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * @throws EventNotFoundException if the {@code key} is not in this {@code AddressBook}.
+     */
+    public boolean removeEvent(ReadOnlyEvent key) throws EventNotFoundException {
+        if (events.remove(key)) {
+            return true;
+        } else {
+            throw new EventNotFoundException();
+        }
+    }
+
+    /**
+     * Sorts the events according to their date time.
+     */
+    public void sortEventList() {
+        events.sortEvents();
+    }
+
+    /*****************************************************
+     * Tag-level operations
+     *****************************************************/
+
+    public void addTag(Tag t) throws UniqueTagList.DuplicateTagException {
+        tags.add(t);
+    }
+
     /**
      * Ensures that every tag in this person:
      *  - exists in the master list {@link #tags}
@@ -193,71 +254,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.forEach(this::syncMasterTagListWith);
     }
 
-    /**
-     * Removes {@code key} from this {@code AddressBook}.
-     * @throws PersonNotFoundException if the {@code key} is not in this {@code AddressBook}.
-     */
-    public boolean removePerson(ReadOnlyPerson key) throws PersonNotFoundException {
-        if (persons.remove(key)) {
-            return true;
-        } else {
-            throw new PersonNotFoundException();
-        }
-    }
-
-    /**
-     * Removes {@code key} from this {@code AddressBook}.
-     * @throws EventNotFoundException if the {@code key} is not in this {@code AddressBook}.
-     */
-    public boolean removeEvent(ReadOnlyEvent key) throws EventNotFoundException {
-        if (events.remove(key)) {
-            return true;
-        } else {
-            throw new EventNotFoundException();
-        }
-    }
-
-    /**
-     * Adds an event to the address book.
-     *
-     * @throws DuplicateEventException if an equivalent event already exists.
-     */
-    public void addEvent(ReadOnlyEvent e) throws DuplicateEventException {
-        Event newEvent = new Event(e);
-        events.add(newEvent);
-    }
-
-    /**
-     * Sorts the events according to time
-     */
-    public void sortEventList() {
-        events.sortEvents();
-    }
-
-    /**
-     * Sorts the persons according to name
-     */
-    public void sortPersonList() {
-        persons.sortPersons();
-    }
-
-
-    /*****************************************************
-     * Tag-level operations
-     *****************************************************/
-
-    public void addTag(Tag t) throws UniqueTagList.DuplicateTagException {
-        tags.add(t);
-    }
-
     /*****************************************************
      * Util methods
      *****************************************************/
 
     @Override
     public String toString() {
-        return persons.asObservableList().size() + " persons, " + tags.asObservableList().size() +  " tags";
         // TODO: refine later
+        return persons.asObservableList().size() + " persons, " + tags.asObservableList().size() +  " tags";
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,21 +58,15 @@ public interface Model {
 
     //=========== Model support for activity component =============================================================
 
-    /** Sorts the events list according to date/time */
-    void sortEventList();
-
-    /** Sorts the persons list according to name */
-    void sortPersonList();
-
     /** Adds an event */
     void addEvent(ReadOnlyEvent event) throws DuplicateEventException;
-
-    /** Deletes the given event */
-    void deleteEvent(ReadOnlyEvent target) throws EventNotFoundException;
 
     /** Updates the given event */
     void updateEvent(ReadOnlyEvent target, ReadOnlyEvent editedEvent)
             throws DuplicateEventException, EventNotFoundException;
+
+    /** Deletes the given event */
+    void deleteEvent(ReadOnlyEvent target) throws EventNotFoundException;
 
     //=========== Filtered Person/Activity List support =============================================================
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -91,15 +91,9 @@ public class ModelManager extends ComponentManager implements Model {
     //=========== Model support for contact component =============================================================
 
     @Override
-    public synchronized void deletePerson(ReadOnlyPerson target) throws PersonNotFoundException {
-        addressBook.removePerson(target);
-        indicateAddressBookChanged();
-    }
-
-    @Override
     public synchronized void addPerson(ReadOnlyPerson person) throws DuplicatePersonException {
         addressBook.addPerson(person);
-        sortPersonList();
+        addressBook.sortPersonList();
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         indicateAddressBookChanged();
     }
@@ -117,16 +111,13 @@ public class ModelManager extends ComponentManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.updatePerson(target, editedPerson);
-        sortPersonList();
+        addressBook.sortPersonList();
         indicateAddressBookChanged();
     }
-    @Override
-    public void updateEvent(ReadOnlyEvent target, ReadOnlyEvent editedEvent)
-            throws DuplicateEventException, EventNotFoundException {
-        requireAllNonNull(target, editedEvent);
 
-        addressBook.updateEvent(target, editedEvent);
-        sortEventList();
+    @Override
+    public synchronized void deletePerson(ReadOnlyPerson target) throws PersonNotFoundException {
+        addressBook.removePerson(target);
         indicateAddressBookChanged();
     }
 
@@ -171,27 +162,26 @@ public class ModelManager extends ComponentManager implements Model {
     //=========== Model support for activity component =============================================================
 
     @Override
-    public void sortEventList() {
+    public synchronized void addEvent(ReadOnlyEvent event) throws DuplicateEventException {
+        requireNonNull(event);
+        addressBook.addEvent(event);
         addressBook.sortEventList();
+        updateFilteredEventsList(PREDICATE_SHOW_ALL_EVENTS);
         indicateAddressBookChanged();
     }
 
     @Override
-    public void sortPersonList() {
-        addressBook.sortPersonList();
+    public void updateEvent(ReadOnlyEvent target, ReadOnlyEvent editedEvent)
+            throws DuplicateEventException, EventNotFoundException {
+        requireAllNonNull(target, editedEvent);
+        addressBook.updateEvent(target, editedEvent);
+        addressBook.sortEventList();
         indicateAddressBookChanged();
     }
 
     @Override
     public synchronized void deleteEvent(ReadOnlyEvent event) throws EventNotFoundException {
         addressBook.removeEvent(event);
-        indicateAddressBookChanged();
-    }
-
-    @Override
-    public synchronized void addEvent(ReadOnlyEvent event) throws DuplicateEventException {
-        addressBook.addEvent(event);
-        updateFilteredEventsList(PREDICATE_SHOW_ALL_EVENTS);
         indicateAddressBookChanged();
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -61,8 +61,8 @@ public class AddEventCommandTest {
 
     @Test
     public void equals() {
-        Event event1 = new EventBuilder().withEventName("Nelsons birthday").build();
-        Event event2 = new EventBuilder().withEventName("Mellys birthday").build();
+        Event event1 = new EventBuilder().withName("Nelsons birthday").build();
+        Event event2 = new EventBuilder().withName("Mellys birthday").build();
         AddEventCommand addEvent1Command = new AddEventCommand(event1);
         AddEventCommand addEvent2Command = new AddEventCommand(event2);
 

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -50,7 +50,7 @@ public class AddEventCommandTest {
 
     @Test
     public void execute_duplicateEvent_throwsCommandException() throws Exception {
-        AddEventModelStub modelStub = new ModelStubThrowingDuplicateEventException();
+        ModelStub modelStub = new ModelStubThrowingDuplicateEventException();
         Event validEvent = new EventBuilder().build();
 
         thrown.expect(CommandException.class);
@@ -93,18 +93,9 @@ public class AddEventCommandTest {
     }
 
     /**
-     * Inherit from default {@link ModelStub}, however, modifying {@link #sortEventList} so that it will not fail.
-     */
-    private class AddEventModelStub extends ModelStub {
-        @Override
-        public void sortEventList()  {
-        }
-    }
-
-    /**
      * A Model stub that always throw a DuplicatePersonException when trying to add a person.
      */
-    private class ModelStubThrowingDuplicatePersonException extends AddEventModelStub {
+    private class ModelStubThrowingDuplicatePersonException extends ModelStub {
         @Override
         public void addPerson(ReadOnlyPerson person) throws DuplicatePersonException {
             throw new DuplicatePersonException();
@@ -119,7 +110,7 @@ public class AddEventCommandTest {
     /**
      * A Model stub that always throw a DuplicateEventException when trying to add a event.
      */
-    private class ModelStubThrowingDuplicateEventException extends AddEventModelStub {
+    private class ModelStubThrowingDuplicateEventException extends ModelStub {
         @Override
         public void addEvent(ReadOnlyEvent event) throws DuplicateEventException {
             throw new DuplicateEventException();
@@ -134,7 +125,7 @@ public class AddEventCommandTest {
     /**
      * A Model stub that always accept the person being added.
      */
-    private class ModelStubAcceptingEventAdded extends AddEventModelStub {
+    private class ModelStubAcceptingEventAdded extends ModelStub {
         final ArrayList<Event> eventsAdded = new ArrayList<>();
 
         @Override
@@ -151,7 +142,7 @@ public class AddEventCommandTest {
     /**
      * A Model stub that always accept the person being added.
      */
-    private class ModelStubAcceptingPersonAdded extends AddEventModelStub {
+    private class ModelStubAcceptingPersonAdded extends ModelStub {
         final ArrayList<Person> personsAdded = new ArrayList<>();
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,7 +30,6 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
-
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Chou";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -65,7 +64,6 @@ public class CommandTestUtil {
     public static final String NAME_DESC_EVENT2 = " " + PREFIX_NAME + VALID_NAME_EVENT2;
     public static final String DATE_DESC_EVENT2 = " " + PREFIX_DATE_TIME + VALID_DATE_EVENT2;
     public static final String VENUE_DESC_EVENT2 = " " + PREFIX_ADDRESS + VALID_VENUE_EVENT2;
-
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
@@ -55,7 +55,7 @@ public class EditEventCommandTest {
         ReadOnlyEvent lastEvent = model.getFilteredEventList().get(indexLastEvent.getZeroBased());
 
         EventBuilder eventInList = new EventBuilder(lastEvent);
-        Event editedEvent = eventInList.withEventName(VALID_NAME_EVENT1).withDateTime(VALID_DATE_EVENT1).build();
+        Event editedEvent = eventInList.withName(VALID_NAME_EVENT1).withDateTime(VALID_DATE_EVENT1).build();
 
         EditEventCommand.EditEventDescriptor descriptor = new EditEventDescriptorBuilder().withName(VALID_NAME_EVENT1)
                 .withTime(VALID_DATE_EVENT1).build();
@@ -87,7 +87,7 @@ public class EditEventCommandTest {
         showFirstEventOnly(model);
 
         ReadOnlyEvent eventInFilteredList = model.getFilteredEventList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Event editedEvent = new EventBuilder(eventInFilteredList).withEventName(VALID_NAME_EVENT1).build();
+        Event editedEvent = new EventBuilder(eventInFilteredList).withName(VALID_NAME_EVENT1).build();
         EditEventCommand editEventCommand = prepareCommand(INDEX_FIRST_PERSON,
                 new EditEventDescriptorBuilder().withName(VALID_NAME_EVENT1).build());
 

--- a/src/test/java/seedu/address/logic/commands/stub/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/stub/ModelStub.java
@@ -35,13 +35,6 @@ public class ModelStub implements Model {
     public void deleteEvent(ReadOnlyEvent event) throws EventNotFoundException {
         fail("This method should not be called.");
     }
-    @Override
-    public void sortEventList() {
-        fail("This method should not be called.");
-    }
-
-    @Override
-    public void sortPersonList() {}
 
     @Override
     public void resetData(ReadOnlyAddressBook newData) {

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -1,10 +1,14 @@
 package seedu.address.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static seedu.address.testutil.TypicalEvents.EVENT1;
 import static seedu.address.testutil.TypicalEvents.EVENT2;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.ALICE_UPDATED;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -23,6 +27,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.ReadOnlyEvent;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
 
 public class AddressBookTest {
@@ -32,11 +37,22 @@ public class AddressBookTest {
 
     private final AddressBook addressBook = new AddressBook();
 
+    /*****************************************************
+     * Test cases for constructors
+     *****************************************************/
+
     @Test
     public void constructor() {
         assertEquals(Collections.emptyList(), addressBook.getPersonList());
         assertEquals(Collections.emptyList(), addressBook.getTagList());
         assertEquals(Collections.emptyList(), addressBook.getEventList());
+    }
+
+    @Test
+    public void alternativeConstructor() {
+        AddressBook origin = getTypicalAddressBook();
+        AddressBook copy = new AddressBook(origin);
+        assertEquals(origin, copy);
     }
 
     @Test
@@ -63,6 +79,7 @@ public class AddressBookTest {
         thrown.expect(AssertionError.class);
         addressBook.resetData(newData);
     }
+
     @Test
     public void resetData_withDuplicateEvents_throwsAssertionError() {
         List<Person> newPersons = Arrays.asList(new Person(ALICE), new Person(BENSON));
@@ -75,11 +92,58 @@ public class AddressBookTest {
         thrown.expect(AssertionError.class);
         addressBook.resetData(newData);
     }
+
+    /*****************************************************
+     * Test cases for persons.
+     *****************************************************/
+
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         addressBook.getPersonList().remove(0);
     }
+
+    @Test
+    public void removePerson_correctCase_checkCorrectness() throws Exception {
+        AddressBook addressBook = getTypicalAddressBook();
+        addressBook.removePerson(ALICE);
+        assertFalse(addressBook.getPersonList().contains(ALICE));
+    }
+
+    @Test
+    public void removePerson_personNotFound_expectException() throws Exception {
+        thrown.expect(PersonNotFoundException.class);
+
+        AddressBook addressBook = getTypicalAddressBook();
+        addressBook.removePerson(HOON);
+    }
+
+    @Test
+    public void sortPersonList_causedByAddPerson_checkSorted() throws Exception {
+        // Adds a new person into typicalAddressBook, who should be placed as the last one after sorting.
+        AddressBook addressBook = getTypicalAddressBook();
+        addressBook.addPerson(AMY);
+        addressBook.sortPersonList();
+
+        // Only Alice should be placed before Amy (order by name incrementally).
+        assertEquals(1, addressBook.getPersonList().indexOf(AMY));
+    }
+
+    @Test
+    public void sortPersonList_causedByUpdatePerson_checkSorted() throws Exception {
+        // Updates the name of an existing person in typicalAddressBook.
+        AddressBook addressBook = getTypicalAddressBook();
+        addressBook.updatePerson(ALICE, ALICE_UPDATED);
+        addressBook.sortPersonList();
+
+        // Now, it should be placed as the last person in the listing since the name has been changed.
+        ObservableList<ReadOnlyPerson> list = addressBook.getPersonList();
+        assertEquals(list.size() - 1, list.indexOf(ALICE_UPDATED));
+    }
+
+    /*****************************************************
+     * Test cases for events.
+     *****************************************************/
 
     @Test
     public void getEventList_modifyList_throwsUnsupportedOperationException() {
@@ -94,13 +158,12 @@ public class AddressBookTest {
     }
 
     /**
-     * A stub ReadOnlyAddressBook whose persons and tags lists can violate interface constraints.
+     * A stub of {@link ReadOnlyAddressBook} whose persons and tags lists can violate interface constraints.
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<ReadOnlyPerson> persons = FXCollections.observableArrayList();
         private final ObservableList<Tag> tags = FXCollections.observableArrayList();
         private final ObservableList<ReadOnlyEvent> events = FXCollections.observableArrayList();
-
 
         AddressBookStub(Collection<? extends ReadOnlyPerson> persons, Collection<? extends ReadOnlyEvent> events,
                         Collection<? extends Tag> tags) {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -78,10 +78,11 @@ public class ModelManagerTest {
         ModelManager modelManager = new ModelManager(addressBook, userPrefs);
         ObservableList<ReadOnlyPerson> persons = modelManager.getAddressBook().getPersonList();
         int originalPersonListSize = persons.size();
-        modelManager.addPerson(TypicalPersons.A1234B);
+        modelManager.addPerson(TypicalPersons.HOON);
         int newPersonListSize = modelManager.getAddressBook().getPersonList().size();
         assertEquals(1, newPersonListSize - originalPersonListSize);
     }
+
     @Test
     public void sortEventList_successfullySortEvent() throws Exception {
         AddressBook addressBook = getTypicalAddressBook();

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -92,7 +92,6 @@ public class ModelManagerTest {
         modelManager.addEvent(TypicalEvents.EVENT1);
         modelManager1.addEvent(TypicalEvents.EVENT1);
         modelManager1.addEvent(TypicalEvents.EVENT2);
-        modelManager.sortEventList();
         System.out.println(modelManager);
         assertEquals(modelManager, modelManager1);
     }

--- a/src/test/java/seedu/address/model/property/EventNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/property/EventNameContainsKeywordsPredicateTest.java
@@ -46,29 +46,29 @@ public class EventNameContainsKeywordsPredicateTest {
         // One keyword
         EventNameContainsKeywordsPredicate predicate =
                 new EventNameContainsKeywordsPredicate(Collections.singletonList("Alice"));
-        assertTrue(predicate.test(new EventBuilder().withEventName("Alice Bob").build()));
+        assertTrue(predicate.test(new EventBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
         predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
-        assertTrue(predicate.test(new EventBuilder().withEventName("Alice Bob").build()));
+        assertTrue(predicate.test(new EventBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
         predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new EventBuilder().withEventName("Alice Carol").build()));
+        assertTrue(predicate.test(new EventBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
         predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
-        assertTrue(predicate.test(new EventBuilder().withEventName("Alice Bob").build()));
+        assertTrue(predicate.test(new EventBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
         EventNameContainsKeywordsPredicate predicate = new EventNameContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new EventBuilder().withEventName("Alice").build()));
+        assertFalse(predicate.test(new EventBuilder().withName("Alice").build()));
 
         // Non-matching keyword
         predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("Carol"));
-        assertFalse(predicate.test(new EventBuilder().withEventName("Alice Bob").build()));
+        assertFalse(predicate.test(new EventBuilder().withName("Alice Bob").build()));
     }
 }

--- a/src/test/java/seedu/address/testutil/EventBuilder.java
+++ b/src/test/java/seedu/address/testutil/EventBuilder.java
@@ -14,8 +14,6 @@ import seedu.address.model.property.exceptions.PropertyNotFoundException;
  * A utility class to help with building Event objects.
  */
 public class EventBuilder {
-
-
     public static final String DEFAULT_EVENT_NAME = "Hack Your Way 2017";
     public static final String DEFAULT_TIME = "25102010 12:00";
     public static final String DEFAULT_VENUE = "123, Clementi West Ave 6, #08-123";
@@ -47,7 +45,7 @@ public class EventBuilder {
     /**
      * Sets the {@code Name} of the {@code Event} that we are building.
      */
-    public EventBuilder withEventName(String name) {
+    public EventBuilder withName(String name) {
         try {
             this.event.setName(new Name(name));
         } catch (IllegalValueException | PropertyNotFoundException ive) {
@@ -55,6 +53,7 @@ public class EventBuilder {
         }
         return this;
     }
+
     /**
      * Sets the {@code Address} of the {@code Event} that we are building.
      */

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -25,18 +25,18 @@ import seedu.address.model.person.exceptions.DuplicateEventException;
  */
 public class TypicalEvents {
 
-    public static final ReadOnlyEvent EVENT1 = new EventBuilder().withEventName("HHN 6001")
+    public static final ReadOnlyEvent EVENT1 = new EventBuilder().withName("HHN 6001")
             .withDateTime("22022015 08:30")
             .withVenue("123, Sentosa, #08-111").build();
-    public static final ReadOnlyEvent EVENT2 = new EventBuilder().withEventName("ZoukOut 6001")
+    public static final ReadOnlyEvent EVENT2 = new EventBuilder().withName("ZoukOut 6001")
             .withDateTime("25122017 10:30")
             .withVenue("123, Clarke Quay #01-111").build();
 
     // Manually added
-    public static final ReadOnlyEvent EVENTM1 = new EventBuilder().withEventName("Volleyball Tour 17")
+    public static final ReadOnlyEvent EVENTM1 = new EventBuilder().withName("Volleyball Tour 17")
             .withDateTime("25122017 08:30")
             .withVenue("OCBC ARENA Hall 3, #01-111").build();
-    public static final ReadOnlyEvent EVENTM2 = new EventBuilder().withEventName("Meeting with Jason")
+    public static final ReadOnlyEvent EVENTM2 = new EventBuilder().withName("Meeting with Jason")
             .withDateTime("25112016 02:30")
             .withVenue("123, Sheraton Towers , #06-111").build();
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.event.ReadOnlyEvent;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.property.PropertyManager;
@@ -24,14 +25,16 @@ import seedu.address.model.property.PropertyManager;
  * A utility class containing a list of {@code Person} objects to be used in tests.
  */
 public class TypicalPersons {
+    /*****************************************************
+     * Sample cases for persons.
+     *****************************************************/
 
+    // These persons will be pre-loaded to typicalAddressBook.
     public static final ReadOnlyPerson ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("85355255")
-            .withTags("friends").build();
+            .withPhone("85355255").withTags("friends").build();
     public static final ReadOnlyPerson BENSON = new PersonBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withAddress("311, Clementi Ave 2, #02-25").withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
     public static final ReadOnlyPerson CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
@@ -57,18 +60,34 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 
-    // Manually added
-    public static final ReadOnlyPerson A1234B = new PersonBuilder().withName("HEHEHAHA").withPhone("9198756")
-            .withEmail("uniqueBoy@example2.com").withAddress("uniqueAve").withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+    // Manually updated - Person's name changed.
+    public static final ReadOnlyPerson ALICE_UPDATED = new PersonBuilder().withName("Zuckerberg Alice Pauline")
+            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+            .withPhone("85355255").withTags("friends").build();
 
-    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+    // A keyword that matches MEIER
+    public static final String KEYWORD_MATCHING_MEIER = "Meier";
+
+    /*****************************************************
+     * Sample cases for events.
+     *****************************************************/
+    public static final ReadOnlyEvent BASKETBALL = new EventBuilder().withName("Basketball practice")
+            .withVenue("OCBC Basketball Court").withDateTime("15102017 11:00").build();
+    public static final ReadOnlyEvent MOVIE = new EventBuilder().withName("Movie with friends")
+            .withVenue("Vivo city Golden Village").withDateTime("20112017 15:00").build();
+    public static final ReadOnlyEvent TUTORIAL = new EventBuilder().withName("CS2103T Tutorial")
+            .withVenue("Basement COM1 NUS").withDateTime("01122017 09:00").build();
 
     static {
         PropertyManager.initializePropertyManager();
     }
 
-    private TypicalPersons() {} // prevents instantiation
+    /**
+     * This is a singleton class, the only constructor was set to private to prevent instantiation.
+     */
+    private TypicalPersons() {
+
+    }
 
     /**
      * Returns an {@code AddressBook} with all the typical persons.
@@ -87,5 +106,9 @@ public class TypicalPersons {
 
     public static List<ReadOnlyPerson> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    public static List<ReadOnlyEvent> getTypicalEvents() {
+        return new ArrayList<>(Arrays.asList(BASKETBALL, MOVIE, TUTORIAL));
     }
 }


### PR DESCRIPTION
- This PR removes sorting mechanism from part of the `Model` interface. Doing so will **debouce** between `Logic` component and `Model` component.
- The changes will not affect the external behaviours of `ModelManager`. This is because, previously the `AddCommand` will call `addPerson` in `ModelManager` anyway.
- Add more test cases.