### PR TITLE
Make all 140 color names in CSS standard available

### DIFF
--- a/collated/main/dennaloh.md
+++ b/collated/main/dennaloh.md
@@ -76,36 +76,6 @@ public class FindTagCommandParser implements Parser<FindTagCommand> {
         }
         return sb.toString();
     }
-
-    public ObjectProperty<UniqueTagList> tagProperty() {
-        return tags;
-    }
-
-    /**
-     * Replaces this person's tags with the tags in the argument tag set.
-     */
-    public void setTags(Set<Tag> replacement) {
-        tags.set(new UniqueTagList(replacement));
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof ReadOnlyPerson // instanceof handles nulls
-                && this.isSameStateAs((ReadOnlyPerson) other));
-    }
-
-    @Override
-    public int hashCode() {
-        // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
-    }
-
-    @Override
-    public String toString() {
-        return getAsText();
-    }
-}
 ```
 ###### \java\seedu\address\model\person\UniquePersonList.java
 ``` java
@@ -114,8 +84,7 @@ public class FindTagCommandParser implements Parser<FindTagCommand> {
      *
      */
     public void sortPersons() {
-        internalList.sort((e1, e2) -> (e1.getName().toString()
-                .compareToIgnoreCase(e2.getName().toString())));
+        internalList.sort((e1, e2) -> e1.getName().toString().compareToIgnoreCase(e2.getName().toString()));
     }
 
     /**

--- a/collated/main/junyango.md
+++ b/collated/main/junyango.md
@@ -677,8 +677,6 @@ public class UniqueEventList implements Iterable<Event> {
 
     /** Deletes the given event */
     void deleteReminder(ReadOnlyReminder target) throws ReminderNotFoundException;
-
-
 ```
 ###### \java\seedu\address\model\ModelManager.java
 ``` java

--- a/collated/test/yunpengn.md
+++ b/collated/test/yunpengn.md
@@ -378,7 +378,7 @@ public class ConfigCommandParserTest {
 
     @Test
     public void parse_usePreDefinedColor_success() throws Exception {
-        ConfigCommand expected = new ChangeTagColorCommand("husband red", "husband", "FF0000");
+        ConfigCommand expected = new ChangeTagColorCommand("husband red", "husband", VALID_PREDEFINED_COLOR.trim());
         assertParseSuccess(parser, VALID_CONFIG_TAG_COLOR + VALID_TAG_HUSBAND + VALID_PREDEFINED_COLOR, expected);
     }
 
@@ -442,6 +442,49 @@ public class ImportCommandParserTest {
         modelManager.setTagColor(myTag, VALID_TAG_COLOR);
         assertEquals(VALID_TAG_COLOR, TagColorManager.getColor(myTag));
     }
+```
+###### \java\seedu\address\model\person\PersonTest.java
+``` java
+public class PersonTest {
+    private static Name name;
+    private static Phone phone;
+    private static Email email;
+    private static Address address;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PropertyManager.initializePropertyManager();
+
+        name = new Name(VALID_NAME_AMY);
+        phone = new Phone(VALID_PHONE_AMY);
+        email = new Email(VALID_EMAIL_AMY);
+        address = new Address(VALID_ADDRESS_AMY);
+    }
+
+    @Test
+    public void createPerson_preDefinedFieldsPresent_checkCorrectness() throws Exception {
+        Person person = new Person(name, phone, email, address, Collections.emptySet());
+        assertNotNull(person);
+
+        assertEquals(name, person.getName());
+        assertEquals(phone, person.getPhone());
+        assertEquals(email, person.getEmail());
+        assertEquals(address, person.getAddress());
+        assertEquals(0, person.getTags().size());
+        assertEquals(4, person.getProperties().size());
+        assertEquals(4, person.getSortedProperties().size());
+    }
+
+    @Test
+    public void equal_twoSameStatePerson_checkCorrectness() throws Exception {
+        Person person = new Person(name, phone, email, address, Collections.emptySet());
+        Person another = new Person(name, phone, email, address, Collections.emptySet());
+        assertEquals(person, another);
+
+        Person copied = new Person(person);
+        assertEquals(person, copied);
+    }
+}
 ```
 ###### \java\seedu\address\model\property\PropertyManagerTest.java
 ``` java
@@ -722,6 +765,14 @@ public class UniquePropertyMapTest {
     }
 
     @Test
+    public void toSortedList_checkCorrectness() throws Exception {
+        UniquePropertyMap propertyMap = createSampleMap();
+        List list = propertyMap.toSortedList();
+        assertEquals(new Property("a", "some address"), list.get(0));
+        assertEquals(new Property("p", "12345678"), list.get(1));
+    }
+
+    @Test
     public void setProperties_validButEmptyInput_successfullySet() throws Exception {
         Set<Property> myNewSet = new HashSet<>();
         UniquePropertyMap propertyMap = createSampleMap();
@@ -783,7 +834,7 @@ public class TagColorManagerTest {
     public void setTagColor_randomColor_checkCorrectness() throws Exception {
         Tag tag = new Tag(VALID_TAG_FRIEND);
         TagColorManager.setColor(tag);
-        assertEquals(6, TagColorManager.getColor(tag).length());
+        assertTrue(TagColorManager.getColor(tag).matches("#[A-Fa-f0-9]{6}"));
     }
 }
 ```

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -360,6 +360,7 @@ Format: `(s)select INDEX`
 * Selects the person/event and loads the details of this data item.
 * The index refers to the index number shown in the most recent listing.
 * The index *must be a positive integer* like `1, 2, 3, ...`
+* All properties of this person/event will be displayed at the right side of the interface (ordered by the name of the property).
 ****
 
 Examples:

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -266,12 +266,14 @@ The index *must be a positive integer* like 1, 2, 3, ...
 
 Examples:
 
-* `editE 1 dt/18052013 03:30 +
+* `editE 1 dt/18052013 03:30` +
 Edits the date/time the 1st event to be `18052013 03:30`.
-* `editE 2 n/Lunch with Betsy  +
+* `editE 2 n/Lunch with Betsy`  +
 Edits the name of the 2nd event to be `Lunch with Betsy`.
 
 === Locating persons/events by any property : `(f)find`
+
+_(`AND` and `OR` search coming in v2.0)_
 
 Finds persons/events whose corresponding field(s) contain any of the given keywords. +
 Format: `(f)find KEYWORD [MORE_KEYWORDS] [p/KEYWORD [MORE_KEYWORDS]]...`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -607,9 +607,9 @@ For `macOS` and `Linux` users, use `/` instead.
 Changes the configuration of the application or applies some advance settings to the data. Make sure you know what you
 are doing before using any of the following commands. These commands are intended for advance users.
 
-==== Add new property : `(cfg)config --add-property`
+==== Adding a customize property : `(cfg)config --add-property`
 
-Adds a new property field available to all persons or events. +
+Adds a new customize property field available to all persons or events. +
 Format: `(cfg)config --add-property s/SHORT_NAME f/FULL_NAME [m/MESSAGE r/REGULAR_EXPRESSION]`
 
 ****
@@ -638,7 +638,9 @@ Example:
 * Regular expression is used to check whether the input value for this property is valid.
 ====
 
-==== Set tag color : `(cfg)config --set-tag-color`
+==== Setting the tag color : `(cfg)config --set-tag-color`
+
+_(Tag feature for events coming in v2.0)_
 
 Sets the displayed color of a certain tag (for persons/events). +
 Format: `(cfg)config --set-tag-color TAG_NAME COLOR`
@@ -646,14 +648,21 @@ Format: `(cfg)config --set-tag-color TAG_NAME COLOR`
 ****
 * By default, the application will use a random color to display each tag. The same tags are displayed using the same
 color, different tags are _usually_ displayed using different colors.
-* The value of the parameter `COLOR` should be either one of the pre-defined color names or a valid RGB value (in hexadecimal,
-starting with a `#`). You can pick the RGB value of your favorite color from https://www.w3schools.com/colors/colors_rgb.asp[here].
-* Pre-defined color names include _black_, _blue_, _brown_, _green_, _red_, _white_, _yellow_.
+* The value of the parameter `COLOR` should be either one of the 140 pre-defined color names or a valid RGB value (a 3-bit
+or 6-bit hexadecimal number starting with a `#`).
+* You can pick the RGB value of your favorite color from https://www.w3schools.com/colors/colors_rgb.asp[here].
+* All legal pre-defined color names can be found from https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#typecolor[here].
 ****
 
 Example:
 
 * `config --set-tag-color friends red`
+
+[NOTE]
+====
+If you enter an invalid color name, the background for that tag will be set to transparent temporarily. You can use this
+again to set it to a legal color.
+====
 
 === Exiting the program : `(x)exit`
 

--- a/src/main/java/seedu/address/commons/events/model/TagColorChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/TagColorChangedEvent.java
@@ -4,6 +4,7 @@ import seedu.address.commons.events.BaseEvent;
 import seedu.address.logic.commands.configs.ChangeTagColorCommand;
 import seedu.address.model.tag.Tag;
 
+//@@author yunpengn
 /**
  * Indicates the color of some tag(s) has been changed.
  */

--- a/src/main/java/seedu/address/logic/commands/configs/ChangeTagColorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/configs/ChangeTagColorCommand.java
@@ -26,6 +26,7 @@ public class ChangeTagColorCommand extends ConfigCommand {
         super(TAG_COLOR, configValue);
 
         try {
+            /* Two tags are equal as long as their tagNames are the same. */
             tag = new Tag(tagName);
         } catch (IllegalValueException e) {
             throw new ParseException(MESSAGE_TAG_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/commands/imports/ImportScriptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/imports/ImportScriptCommand.java
@@ -14,6 +14,6 @@ public class ImportScriptCommand extends ImportCommand {
 
     @Override
     public CommandResult executeUndoableCommand() throws CommandException {
-        return null;
+        return new CommandResult("The script has been imported.");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ConfigCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ConfigCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SHORT_NAME;
 import static seedu.address.model.property.PropertyManager.DEFAULT_MESSAGE;
 import static seedu.address.model.property.PropertyManager.DEFAULT_REGEX;
 
-import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -137,8 +136,8 @@ public class ConfigCommandParser implements Parser<ConfigCommand> {
     }
 
     /**
-     * Checks whether the given string is a valid RGB value or a fully-alphabetical string (we do not check whether it is
-     * one of the 140 pre-defined CSS color names).
+     * Checks whether the given string is a valid RGB value or a fully-alphabetical string (we do not check whether it
+     * is one of the 140 pre-defined CSS color names).
      *
      * TODO: Search for any API to check whether it is one of 140 pre-defined names.
      *

--- a/src/main/java/seedu/address/logic/parser/ConfigCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ConfigCommandParser.java
@@ -35,24 +35,10 @@ public class ConfigCommandParser implements Parser<ConfigCommand> {
     /* Regular expressions for validation. ArgumentMultiMap not applicable here. */
     private static final Pattern CONFIG_COMMAND_FORMAT = Pattern.compile("--(?<configType>\\S+)(?<configValue>.+)");
     private static final Pattern TAG_COLOR_FORMAT = Pattern.compile("(?<tagName>\\p{Alnum}+)\\s+(?<tagNewColor>.+)");
-    private static final Pattern RGB_FORMAT = Pattern.compile("#(?<rgbValue>([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$)");
-
-    // Some pre-defined colors for convenience.
-    private static final HashMap<String, String> preDefinedColors = new HashMap<>();
-
-    /**
-     * Loads all pre-defined colors here. If you want to define more, you can get more color codes can be obtained from
-     * https://www.w3schools.com/colors/colors_names.asp Make sure you put them in alphabetical order.
-     */
-    static {
-        preDefinedColors.put("black", "#000000");
-        preDefinedColors.put("blue", "#0000FF");
-        preDefinedColors.put("brown", "#A52A2A");
-        preDefinedColors.put("green", "#008000");
-        preDefinedColors.put("red", "#FF0000");
-        preDefinedColors.put("white", "#FFFFFF");
-        preDefinedColors.put("yellow", "#FFFF00");
-    }
+    // A valid RGB value should be 3-bit or 6-bit hexadecimal number.
+    private static final Pattern RGB_FORMAT = Pattern.compile("#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})");
+    // Only contains alphabets (a-z or A-Z)
+    private static final Pattern ONLY_ALPHABET = Pattern.compile("[a-zA-Z]+");
 
     @Override
     public ConfigCommand parse(String args) throws ParseException {
@@ -108,21 +94,16 @@ public class ConfigCommandParser implements Parser<ConfigCommand> {
                     ChangeTagColorCommand.MESSAGE_USAGE));
         }
 
+        // Get the tag name and the customize new color for that tag.
         final String tagName = matcher.group("tagName").trim();
         String tagColor = matcher.group("tagNewColor").trim();
 
-        // Use the corresponding RGB value to replace pre-defined color names.
-        if (preDefinedColors.containsKey(tagColor)) {
-            tagColor = preDefinedColors.get(tagColor);
-        }
-
-        matcher = RGB_FORMAT.matcher(tagColor.trim());
-        if (!matcher.matches()) {
+        // Checks whether the given color is valid.
+        if (!isValidColorCode(tagColor)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, COLOR_CODE_WRONG));
         }
-        String colorRgbValue = matcher.group("rgbValue").trim();
 
-        return new ChangeTagColorCommand(value, tagName, colorRgbValue);
+        return new ChangeTagColorCommand(value, tagName, tagColor);
     }
 
     /**
@@ -153,6 +134,21 @@ public class ConfigCommandParser implements Parser<ConfigCommand> {
         String regex = argMultimap.getValue(PREFIX_REGEX).orElse(DEFAULT_REGEX);
 
         return new AddPropertyCommand(value, shortName, fullName, message, regex);
+    }
+
+    /**
+     * Checks whether the given string is a valid RGB value or a fully-alphabetical string (we do not check whether it is
+     * one of the 140 pre-defined CSS color names).
+     *
+     * TODO: Search for any API to check whether it is one of 140 pre-defined names.
+     *
+     * @see <a href=https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#typecolor>
+     *     JavaFX CSS Reference Guide</a>
+     */
+    private boolean isValidColorCode(String color) {
+        // Either all letters or a valid RGB value.
+        return ONLY_ALPHABET.matcher(color).matches() || RGB_FORMAT.matcher(color).matches();
+
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -38,9 +38,11 @@ public interface Model {
 
     //=========== Model support for property component =============================================================
 
+    //@@author yunpengn
     /** Adds a new customize property */
     void addProperty(String shortName, String fullName, String message, String regex)
             throws DuplicatePropertyException, PatternSyntaxException;
+    //@@author
 
     //=========== Model support for contact component =============================================================
 
@@ -62,8 +64,11 @@ public interface Model {
     /** Checks whether there exists a tag (with the same tagName) */
     boolean hasTag(Tag tag);
 
+    //@@author yunpengn
     /** Changes the color of an existing tag (through TagColorManager) */
     void setTagColor(Tag tag, String color);
+    //@@author
+
     //@@author junyango
     //=========== Model support for activity component =============================================================
 
@@ -84,9 +89,8 @@ public interface Model {
 
     /** Deletes the given event */
     void deleteReminder(ReadOnlyReminder target) throws ReminderNotFoundException;
-
-
     //@@author
+
     //=========== Filtered Person/Activity List support =============================================================
 
     /** Returns an unmodifiable view of the filtered person list */

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -161,6 +162,7 @@ public class Person implements ReadOnlyPerson {
         return address.get();
     }
 
+    //@@author yunpengn
     @Override
     public ObjectProperty<UniquePropertyMap> properties() {
         return properties;
@@ -174,6 +176,12 @@ public class Person implements ReadOnlyPerson {
     public Set<Property> getProperties() {
         return Collections.unmodifiableSet(properties.get().toSet());
     }
+
+    @Override
+    public List<Property> getSortedProperties() {
+        return Collections.unmodifiableList(properties().get().toList());
+    }
+
 
     /**
      * Replaces this person's properties with the properties in the argument tag set.
@@ -193,6 +201,7 @@ public class Person implements ReadOnlyPerson {
     public void setProperty(Property toSet) {
         properties.get().addOrUpdate(toSet);
     }
+    //@@author
 
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
@@ -217,6 +226,7 @@ public class Person implements ReadOnlyPerson {
         }
         return sb.toString();
     }
+    //@@author
 
     public ObjectProperty<UniqueTagList> tagProperty() {
         return tags;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -179,7 +179,7 @@ public class Person implements ReadOnlyPerson {
 
     @Override
     public List<Property> getSortedProperties() {
-        return Collections.unmodifiableList(properties().get().toList());
+        return Collections.unmodifiableList(properties().get().toSortedList());
     }
 
 

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.util.List;
 import java.util.Set;
 
 import javafx.beans.property.ObjectProperty;
@@ -28,6 +29,7 @@ public interface ReadOnlyPerson {
     Address getAddress();
     ObjectProperty<UniquePropertyMap> properties();
     Set<Property> getProperties();
+    List<Property> getSortedProperties();
     ObjectProperty<UniqueTagList> tagProperty();
     Set<Tag> getTags();
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -55,8 +55,7 @@ public class UniquePersonList implements Iterable<Person> {
      *
      */
     public void sortPersons() {
-        internalList.sort((e1, e2) -> (e1.getName().toString()
-                .compareToIgnoreCase(e2.getName().toString())));
+        internalList.sort((e1, e2) -> e1.getName().toString().compareToIgnoreCase(e2.getName().toString()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/property/UniquePropertyMap.java
+++ b/src/main/java/seedu/address/model/property/UniquePropertyMap.java
@@ -60,7 +60,7 @@ public class UniquePropertyMap implements Iterable<Property> {
      * Returns all properties (collection of values in all entries) in this map as a sorted list based on the full
      * name of each property. This list is mutable but change-insulated against the internal map.
      */
-    public List<Property> toList() {
+    public List<Property> toSortedList() {
         List<Property> list = new ArrayList<>(internalMap.values());
         list.sort(Comparator.comparing(Property::getFullName));
         return list;

--- a/src/main/java/seedu/address/model/property/UniquePropertyMap.java
+++ b/src/main/java/seedu/address/model/property/UniquePropertyMap.java
@@ -4,8 +4,11 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.PROPERTY_EXISTS;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import javafx.collections.FXCollections;
@@ -47,10 +50,20 @@ public class UniquePropertyMap implements Iterable<Property> {
 
     /**
      * Returns all properties (collection of values in all entries) in this map as a Set. This set is mutable
-     * and change-insulated against the internal list.
+     * but change-insulated against the internal map.
      */
     public Set<Property> toSet() {
         return new HashSet<>(internalMap.values());
+    }
+
+    /**
+     * Returns all properties (collection of values in all entries) in this map as a sorted list based on the full
+     * name of each property. This list is mutable but change-insulated against the internal map.
+     */
+    public List<Property> toList() {
+        List<Property> list = new ArrayList<>(internalMap.values());
+        list.sort(Comparator.comparing(Property::getFullName));
+        return list;
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/TagColorManager.java
+++ b/src/main/java/seedu/address/model/tag/TagColorManager.java
@@ -21,6 +21,8 @@ public class TagColorManager {
     // Random number generator (non-secure purpose)
     private static final Random randomGenerator = new Random();
 
+    private static final String TAG_NOT_FOUND = "The provided tag does not exist.";
+
     /**
      * The upper (exclusive) bound should be equal to {@code Math.pow(16, 6)}. The lower (inclusive) bound should be
      * equal to {@code Math.pow(16, 5)}. Thus, the interval is {@code Math.pow(16, 6) - Math.pow(16, 5)}.
@@ -30,7 +32,7 @@ public class TagColorManager {
 
     public static String getColor(Tag tag) throws TagNotFoundException {
         if (!internalMap.containsKey(tag)) {
-            throw new TagNotFoundException();
+            throw new TagNotFoundException(TAG_NOT_FOUND);
         }
 
         return internalMap.get(tag);

--- a/src/main/java/seedu/address/model/tag/TagColorManager.java
+++ b/src/main/java/seedu/address/model/tag/TagColorManager.java
@@ -56,6 +56,6 @@ public class TagColorManager {
      */
     public static void setColor(Tag tag) {
         int randomColorCode = randomGenerator.nextInt(RGB_INTERVAL) + RGB_LOWER_BOUND;
-        setColor(tag, Integer.toHexString(randomColorCode));
+        setColor(tag, "#" + Integer.toHexString(randomColorCode));
     }
 }

--- a/src/main/java/seedu/address/model/tag/exceptions/TagNotFoundException.java
+++ b/src/main/java/seedu/address/model/tag/exceptions/TagNotFoundException.java
@@ -4,4 +4,12 @@ package seedu.address.model.tag.exceptions;
  * Signals that the required property has not been defined yet.
  */
 public class TagNotFoundException extends Exception {
+    public TagNotFoundException(String message) {
+        super(message);
+    }
+
+    @Override
+    public String toString() {
+        return getMessage();
+    }
 }

--- a/src/main/java/seedu/address/ui/person/PersonCard.java
+++ b/src/main/java/seedu/address/ui/person/PersonCard.java
@@ -19,6 +19,7 @@ import seedu.address.ui.UiPart;
  */
 public class PersonCard extends UiPart<Region> {
     private static final String FXML = "person/PersonListCard.fxml";
+    private static final String TAG_COLOR_CSS = "-fx-background-color: %s";
 
     // Keep a record of the displayed persons.
     public final ReadOnlyPerson person;
@@ -69,6 +70,7 @@ public class PersonCard extends UiPart<Region> {
         });
     }
 
+    //@@author yunpengn
     /**
      * Initializes all the tags of a person displayed in different random colors.
      */
@@ -77,7 +79,7 @@ public class PersonCard extends UiPart<Region> {
             String tagName = tag.tagName;
             Label newTagLabel = new Label(tagName);
             try {
-                newTagLabel.setStyle(String.format("-fx-background-color: #%s", TagColorManager.getColor(tag)));
+                newTagLabel.setStyle(String.format(TAG_COLOR_CSS, TagColorManager.getColor(tag)));
             } catch (TagNotFoundException e) {
                 System.err.println("An existing must have a color.");
             }
@@ -91,6 +93,7 @@ public class PersonCard extends UiPart<Region> {
         tags.getChildren().clear();
         initTags();
     }
+    //@@author yunpengn
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/ui/person/PersonDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/person/PersonDetailsPanel.java
@@ -44,7 +44,7 @@ public class PersonDetailsPanel extends UiPart<Region> {
         List<Label> keys = new ArrayList<>();
         List<Label> values = new ArrayList<>();
 
-        person.getProperties().forEach(property -> {
+        person.getSortedProperties().forEach(property -> {
             Label newPropertyKey = new PropertyLabel(property.getFullName() + ":", "details-property-key");
             Label newPropertyValue = new PropertyLabel(property.getValue(), "details-property-value");
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -89,7 +89,7 @@ public class CommandTestUtil {
 
     public static final String INVALID_CONFIG_TYPE = " --some-config-type-unknown ";
     public static final String INVALID_CONFIG_VALUE = " unknown value(s)";
-    public static final String INVALID_TAG_COLOR = " bee";
+    public static final String INVALID_TAG_COLOR = " bee1";
     public static final String INVALID_NEW_PROPERTY = " s/b r/[^\\s].*";
 
     public static final String INVALID_IMPORT_TYPE = " --some-import-type-unknown ";

--- a/src/test/java/seedu/address/logic/commands/imports/ImportScriptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/imports/ImportScriptCommandTest.java
@@ -1,13 +1,8 @@
 package seedu.address.logic.commands.imports;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
-
-import seedu.address.logic.CommandHistory;
-import seedu.address.logic.UndoRedoStack;
-import seedu.address.logic.commands.stub.ModelStub;
 
 public class ImportScriptCommandTest {
     @Test

--- a/src/test/java/seedu/address/logic/commands/imports/ImportScriptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/imports/ImportScriptCommandTest.java
@@ -1,0 +1,18 @@
+package seedu.address.logic.commands.imports;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.logic.commands.stub.ModelStub;
+
+public class ImportScriptCommandTest {
+    @Test
+    public void createCommand_allPresent_checkCorrectness() throws Exception {
+        ImportCommand command = new ImportScriptCommand("some script file");
+        assertNotNull(command);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ConfigCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ConfigCommandParserTest.java
@@ -48,7 +48,7 @@ public class ConfigCommandParserTest {
 
     @Test
     public void parse_usePreDefinedColor_success() throws Exception {
-        ConfigCommand expected = new ChangeTagColorCommand("husband red", "husband", "FF0000");
+        ConfigCommand expected = new ChangeTagColorCommand("husband red", "husband", VALID_PREDEFINED_COLOR.trim());
         assertParseSuccess(parser, VALID_CONFIG_TAG_COLOR + VALID_TAG_HUSBAND + VALID_PREDEFINED_COLOR, expected);
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -1,0 +1,61 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+
+import java.util.Collections;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import seedu.address.model.property.Address;
+import seedu.address.model.property.Email;
+import seedu.address.model.property.Name;
+import seedu.address.model.property.Phone;
+import seedu.address.model.property.PropertyManager;
+
+//@@author yunpengn
+public class PersonTest {
+    private static Name name;
+    private static Phone phone;
+    private static Email email;
+    private static Address address;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PropertyManager.initializePropertyManager();
+
+        name = new Name(VALID_NAME_AMY);
+        phone = new Phone(VALID_PHONE_AMY);
+        email = new Email(VALID_EMAIL_AMY);
+        address = new Address(VALID_ADDRESS_AMY);
+    }
+
+    @Test
+    public void createPerson_preDefinedFieldsPresent_checkCorrectness() throws Exception {
+        Person person = new Person(name, phone, email, address, Collections.emptySet());
+        assertNotNull(person);
+
+        assertEquals(name, person.getName());
+        assertEquals(phone, person.getPhone());
+        assertEquals(email, person.getEmail());
+        assertEquals(address, person.getAddress());
+        assertEquals(0, person.getTags().size());
+        assertEquals(4, person.getProperties().size());
+        assertEquals(4, person.getSortedProperties().size());
+    }
+
+    @Test
+    public void equal_twoSameStatePerson_checkCorrectness() throws Exception {
+        Person person = new Person(name, phone, email, address, Collections.emptySet());
+        Person another = new Person(name, phone, email, address, Collections.emptySet());
+        assertEquals(person, another);
+
+        Person copied = new Person(person);
+        assertEquals(person, copied);
+    }
+}

--- a/src/test/java/seedu/address/model/property/UniquePropertyMapTest.java
+++ b/src/test/java/seedu/address/model/property/UniquePropertyMapTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.BeforeClass;
@@ -123,6 +124,14 @@ public class UniquePropertyMapTest {
     public void toSet_checkCorrectness() throws Exception {
         UniquePropertyMap propertyMap = createSampleMap();
         assertEquals(mySet, propertyMap.toSet());
+    }
+
+    @Test
+    public void toSortedList_checkCorrectness() throws Exception {
+        UniquePropertyMap propertyMap = createSampleMap();
+        List list = propertyMap.toSortedList();
+        assertEquals(new Property("a", "some address"), list.get(0));
+        assertEquals(new Property("p", "12345678"), list.get(1));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/tag/TagColorManagerTest.java
+++ b/src/test/java/seedu/address/model/tag/TagColorManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.model.tag;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COLOR;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -37,6 +38,6 @@ public class TagColorManagerTest {
     public void setTagColor_randomColor_checkCorrectness() throws Exception {
         Tag tag = new Tag(VALID_TAG_FRIEND);
         TagColorManager.setColor(tag);
-        assertEquals(6, TagColorManager.getColor(tag).length());
+        assertTrue(TagColorManager.getColor(tag).matches("#[A-Fa-f0-9]{6}"));
     }
 }

--- a/src/test/java/seedu/address/model/tag/TagNotFoundExceptionTest.java
+++ b/src/test/java/seedu/address/model/tag/TagNotFoundExceptionTest.java
@@ -1,0 +1,19 @@
+package seedu.address.model.tag;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.model.tag.exceptions.TagNotFoundException;
+
+public class TagNotFoundExceptionTest {
+    private ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void createException_toString_checkCorrectness() throws Exception {
+        thrown.expect(TagNotFoundException.class);
+        Exception exception = new TagNotFoundException("Some message here");
+        assertEquals("Some message here", exception.toString());
+    }
+}


### PR DESCRIPTION
Apart from enhacing the `ChangeTagColorCommand`, this PR also

- Update UserGuide about `ChangeTagColorCommand`
- Mark some sections as "_Coming in v2.0_" in the UserGuide
- Display person details in order by property full names.